### PR TITLE
Suggested change: Alternate app icon suggestion for iPad

### DIFF
--- a/AlternateIconTest/Info.plist
+++ b/AlternateIconTest/Info.plist
@@ -35,6 +35,35 @@
 			</array>
 		</dict>
 	</dict>
+    <key>CFBundleIcons~ipad</key>
+    <dict>
+        <key>CFBundleAlternateIcons</key>
+        <dict>
+            <key>Test1</key>
+            <dict>
+                <key>CFBundleIconFiles</key>
+                <array>
+                    <string>Test1</string>
+                </array>
+                <key>UIPrerenderedIcon</key>
+                <false/>
+            </dict>
+            <key>Test2</key>
+            <dict>
+                <key>CFBundleIconFiles</key>
+                <array>
+                    <string>Test2</string>
+                </array>
+            </dict>
+        </dict>
+        <key>CFBundlePrimaryIcon</key>
+        <dict>
+            <key>CFBundleIconFiles</key>
+            <array>
+                <string>AppIcon60x60</string>
+            </array>
+        </dict>
+    </dict>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
I'm not entirely sure the default section is required within `CFBundleIcons~ipad` as setting the default already works as expected but I did it in my own project as I did a lazy copy / paste. 

If you want it without the default being included feel free to decline over that. 